### PR TITLE
Update action.yml

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   bot:
-    # 运行环境，Ubuntu
-    runs-on: ubuntu-latest
+    # 运行环境，Ubuntu-20.04
+    runs-on: Ubuntu-20.04
     steps:
       # 检测代码
       - name: 'Checkout codes'


### PR DESCRIPTION
ubuntu-latest不再支持python3.6
[Python 3.6 x64 on Linux: Error: Version 3.6 with arch x64 not found](https://github.com/actions/setup-python/issues/544)
再提一点建议，如果能把这个repo设置为template就更好了，因为fork的话原commit的内容还会保留。